### PR TITLE
fix(cd): sync Vertex env vars on backend Cloud Run deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,7 @@ env:
   PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
   PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}
   REGION: asia-northeast1
+  VERTEX_LOCATION: global
   ARTIFACT_REPOSITORY: madamis-ai
   BACKEND_SERVICE: madamis-backend
   FRONTEND_SERVICE: madamis-frontend
@@ -75,10 +76,14 @@ jobs:
 
       - name: Deploy backend
         run: |
+          # Image-only updates leave stale env (e.g. GOOGLE_API_KEY after Vertex migration).
+          # Keep env aligned with terraform/main.tf backend Cloud Run template.
           gcloud run services update "${BACKEND_SERVICE}" \
             --project="${PROJECT_ID}" \
             --region="${REGION}" \
-            --image="${{ steps.images.outputs.backend_image }}"
+            --image="${{ steps.images.outputs.backend_image }}" \
+            --remove-env-vars=GOOGLE_API_KEY \
+            --update-env-vars="^|^GOOGLE_GENAI_USE_VERTEXAI=1|GOOGLE_CLOUD_PROJECT=${PROJECT_ID}|GOOGLE_CLOUD_LOCATION=${VERTEX_LOCATION}|ADK_SESSION_SERVICE=firestore|FIRESTORE_PROJECT_ID=${PROJECT_ID}|FIRESTORE_DATABASE_ID=(default)|ADK_FIRESTORE_ROOT_COLLECTION=adk-session"
 
       - name: Read backend URL
         id: backend

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ npm test
 ## 🚀 GCP デプロイと CI
 
 `terraform/` には GCP 用の定義（Cloud Run、Compute Engine、Secret Manager、Artifact Registry など）があります。  
-**GitHub Actions による CD は現状未実装**です。本番では Docker ビルド・レジストリへのプッシュ・`terraform apply` を手動または別パイプラインで行う想定です。
+**GitHub Actions**: `main` 向け CI 成功後に CD（[`.github/workflows/cd.yml`](.github/workflows/cd.yml)）が Cloud Run へイメージと backend 環境変数をデプロイします。Terraform で IAM や新リソースを変えたときは **`terraform apply` も実行**してください（例: Vertex AI 権限 `roles/aiplatform.user`）。
 
 ### インフラ構成（Terraform 想定）
 


### PR DESCRIPTION
## Summary
- PR #5 の Vertex 移行後、CD がイメージだけ更新して Cloud Run の env が古いまま（`GOOGLE_API_KEY` のみ）だった
- 起動時 `ensure_llm_config()` が `GOOGLE_CLOUD_*` 不足で落ち、PORT=8000 を listen する前に revision が失敗していた

## Changes
| ファイル | 内容 |
| --- | --- |
| `.github/workflows/cd.yml` | backend デプロイ時に Vertex / Firestore env を `terraform/main.tf` と同期、`GOOGLE_API_KEY` を削除 |
| `README.md` | CD の説明を現状に合わせて更新 |

## Test plan
- [ ] マージ後 CD 再実行で `madamis-backend` revision が Ready になる
- [ ] `GET /health` が 200 を返す
- [ ] （未 apply なら）`terraform apply` で `roles/aiplatform.user` 付与済みであること